### PR TITLE
perf(pencil): remove graphiteWidth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ $ pip install testpackagemds
 
 ## Usage
 
-
-
 ## Contributing
 
 Interested in contributing? Check out the contributing guidelines. Please note that this project is released with a Code of Conduct. By contributing to this project, you agree to abide by its terms.


### PR DESCRIPTION
BREAKING CHANGE: The graphiteWidth option has been removed.
The default graphite width of 10mm is always used for performance reasons.